### PR TITLE
Fix Syntax Highlighting of Arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Syntax highlighting of arguments, strings, and numbers in SLURM directives.
+- Different colors for disabled `##SLURM` lines for other themes.
 
 ## [0.0.1] - 2024-11-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Language icon for `.sbatch` files without using the File Icon Theme.
+
+### Fixed
+- Syntax highlighting of arguments, strings, and numbers in SLURM directives.
+
 ## [0.0.1] - 2024-11-02
 ### Added
 - Initial release with syntax highlighting for `.sbatch` files.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
         "id": "sbatch",
         "aliases": ["SBATCH", "sbatch"],
         "extensions": [".sbatch"],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "./images/svg/sbatch.svg",
+          "light": "./images/svg/sbatch.svg"
+        }
       }
     ],
     "grammars": [

--- a/sample.sbatch
+++ b/sample.sbatch
@@ -1,0 +1,32 @@
+# "SBATCH" only
+#SBATCH
+# With trailing space
+#SBATCH   
+# Missing argument
+#SBATCH --
+# Standard parameter + options
+#SBATCH --job-name=my_job
+# With spaces
+#SBATCH --job-name = my_job
+# Numeric value
+#SBATCH --ntasks=4
+# Numeric with trailing space
+#SBATCH --nodes=4  
+# Value with inline comment
+#SBATCH --nodes=4  # Comment
+# Time value
+#SBATCH --time=01:00:00
+# Parameter without a value or "="
+#SBATCH --output
+# Parameter without a value
+#SBATCH --output=
+# Path with leading slash
+#SBATCH --output=/Filepath
+# Quoted path with spaces
+#SBATCH --error="/Filepath/with spaces"
+# Quoted relative path
+#SBATCH --error="filepath.err"
+# Filepath with slurm variable substitution
+#SBATCH --output=output%j.out
+# Disabled
+##SBATCH --Disabled command

--- a/syntaxes/sbatch.tmLanguage.json
+++ b/syntaxes/sbatch.tmLanguage.json
@@ -2,7 +2,7 @@
   "scopeName": "source.sbatch",
   "patterns": [
     {
-      "begin": "^\\s*(#SBATCH)(\\s+(--[a-zA-Z-_]+)?\\s*(=)?)?",
+      "begin": "^(#SBATCH)(\\s+(--[a-zA-Z-_]+)?\\s*(=)?)?",
       "end": "$",
       "beginCaptures": {
         "1": {"name": "keyword.control.sbatch"},

--- a/syntaxes/sbatch.tmLanguage.json
+++ b/syntaxes/sbatch.tmLanguage.json
@@ -2,24 +2,39 @@
   "scopeName": "source.sbatch",
   "patterns": [
     {
-      "name": "keyword.control.sbatch", 
-      "match": "^#SBATCH\\b.*"
+      "match": "^\\s*(#SBATCH)(\\s+(?:(--[a-zA-Z-_]+)?\\s*(=)?\\s*(?:(\\d+(?:\\.\\d+)?)|(\".*?\")|.+?)*)|.*)?",
+      "captures": {
+        "1": {
+          "name": "keyword.control.sbatch"
+        },
+        "2": {
+          "name": "meta.argument.sbatch"
+        },
+        "3": {
+          "name": "variable.parameter.sbatch",
+          "comment": "\\b--[a-zA-Z-]+\\b"
+        },
+        "4": {
+          "name": "keyword.operator.assignment.sbatch",
+          "comment": "\\b=\\b"
+        },
+        "5": {
+          "name": "constant.numeric.sbatch",
+          "comment": "\\b\\d+\\b"
+        },
+        "6": {
+          "name": "string.quoted.sbatch",
+          "comment": "\".*?\""
+        },
+        "7": {
+          "name": "variable.other.sbatch",
+          "comment": "\\w+"
+        }
+      }
     },
     {
       "name": "keyword.line.sbatch-param",  
       "match": "^##SBATCH\\b.*"
-    },
-    {
-      "name": "variable.parameter.sbatch",
-      "match": "\\b(--[a-zA-Z-]+)\\b"
-    },
-    {
-      "name": "constant.numeric.sbatch",
-      "match": "\\b\\d+\\b"
-    },
-    {
-      "name": "string.quoted.sbatch",
-      "match": "\".*?\""
     },
     {
       "include": "source.shell"  

--- a/syntaxes/sbatch.tmLanguage.json
+++ b/syntaxes/sbatch.tmLanguage.json
@@ -46,8 +46,9 @@
       ]
     },
     {
-      "name": "keyword.line.sbatch-param",  
-      "match": "^##SBATCH\\b.*"
+      "name": "storage.type.disabled.sbatch meta.disabled.sbatch",
+      "match": "^##SBATCH\\b.*",
+      "comment": "This scope doesn't really make sense, but it does serve to highlight disabled SBATCH directives differently."
     },
     {
       "include": "source.shell"  

--- a/syntaxes/sbatch.tmLanguage.json
+++ b/syntaxes/sbatch.tmLanguage.json
@@ -2,35 +2,48 @@
   "scopeName": "source.sbatch",
   "patterns": [
     {
-      "match": "^\\s*(#SBATCH)(\\s+(?:(--[a-zA-Z-_]+)?\\s*(=)?\\s*(?:(\\d+(?:\\.\\d+)?)|(\".*?\")|.+?)*)|.*)?",
-      "captures": {
-        "1": {
-          "name": "keyword.control.sbatch"
-        },
-        "2": {
-          "name": "meta.argument.sbatch"
-        },
-        "3": {
-          "name": "variable.parameter.sbatch",
-          "comment": "\\b--[a-zA-Z-]+\\b"
-        },
-        "4": {
-          "name": "keyword.operator.assignment.sbatch",
-          "comment": "\\b=\\b"
-        },
-        "5": {
+      "begin": "^\\s*(#SBATCH)(\\s+(--[a-zA-Z-_]+)?\\s*(=)?)?",
+      "end": "$",
+      "beginCaptures": {
+        "1": {"name": "keyword.control.sbatch"},
+        "2": {"name": "meta.argument.sbatch"},
+        "3": {"name": "variable.parameter.sbatch"},
+        "4": {"name": "keyword.operator.assignment.sbatch"}
+      },
+      "contentName": "meta.argument.sbatch",
+      "patterns": [
+        {
           "name": "constant.numeric.sbatch",
-          "comment": "\\b\\d+\\b"
+          "match": "\\b\\d+(?:\\.\\d*)?\\b"
         },
-        "6": {
-          "name": "string.quoted.sbatch",
-          "comment": "\".*?\""
+        {
+          "name": "string.quoted.double.sbatch",
+          "begin": "\"",
+          "end": "\"",
+          "beginCaptures": {
+            "0": {"name": "punctuation.definition.string.begin.sbatch"}
+          },
+          "endCaptures": {
+            "0": {"name": "punctuation.definition.string.end.sbatch"}
+          },
+          "patterns": [
+            {
+              "include": "#filename_variable"
+            }
+          ]
         },
-        "7": {
+        {
+          "include": "#filename_variable"
+        },
+        {
+          "name": "comment.line.sbatch",
+          "match": "#.*"
+        },
+        {
           "name": "variable.other.sbatch",
-          "comment": "\\w+"
+          "match": "\\w+"
         }
-      }
+      ]
     },
     {
       "name": "keyword.line.sbatch-param",  
@@ -39,5 +52,11 @@
     {
       "include": "source.shell"  
     }
-  ]
+  ],
+  "repository": {
+    "filename_variable": {
+      "name": "constant.character.format.placeholder.other.sbatch",
+      "match": "%\\d*[a-zA-Z%]"
+    }
+  }
 }


### PR DESCRIPTION
Thanks for your work on this extension!

### Added
- **Syntax Highlighting**: I did my best to fix the syntax highlighting of arguments in `#SBATCH` directives. It may not be fully faithful to SLURM's implementation, but I tried to make something that users would expect to see.
  
  | Before | After |
  |:------:|:-----:|
  |<img width="300" alt="image" src="https://github.com/user-attachments/assets/238cc9cc-d9fd-4e46-8894-af4e0accbaf6" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/aeb77b54-5f52-4fb9-a3f0-d518687444e8" />|

- **File Icon**: I also added the slurm icon to the language definition so that it displays on `.sbatch` files without needing to switch the full icon theme.

### Fixed

- **Different coloring of `##SBATCH`** lines in third-party themes. (Fixes #1)
  > The original highlighting used a TM scope of `keyword.control.sbatch` for `#SBATCH` lines and `keyword.line.sbatch-param` for `##SBATCH` lines, however, many themes don't distinguish colors for different `keyword` scopes. Now, `##SBATCH` lines use the `storage.type.disabled.sbatch` scope. This scope doesn't really make sense based on the context, but it uses the same color in the default theme as before (`#569CD6`) and is more likely to be styled differently in other themes. 